### PR TITLE
Made the API recognise how to handle if the client returns null

### DIFF
--- a/Controllers/ClientController.cs
+++ b/Controllers/ClientController.cs
@@ -91,16 +91,16 @@ namespace WebAPI.Controllers
         {
             var client = clients.Find(c => c.Id.Equals(id));
 
-            if (client.Id != null)
+            if (client == null || client.Id == null)
+            {
+                return NotFound("Client not found");
+            }
+            else
             {
                 clients.RemoveAll(c => c.Id == id);
                 addresses.RemoveAll(a => a.ClientId == id);
                 cars.RemoveAll(c => c.ClientId == id);
                 return Ok("Client deleted successfully");
-            }
-            else
-            {
-                return NotFound("Client not found");
             }
         }
 


### PR DESCRIPTION
Code was falling over when client was being returned null. It handled client.Id being null but not client on its own